### PR TITLE
Feat8 be confirm delivery

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,10 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "prisma:migrate": "prisma migrate dev",
-    "prisma:generate": "prisma generate"
+    "prisma:generate": "prisma generate",
+    "prisma:seed": "ts-node prisma/seed.ts",
+    "db:reset": "prisma migrate reset --force && npm run prisma:seed",
+    "check:data": "ts-node scripts/check-data.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.857.0",
@@ -75,6 +78,9 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/backend/src/shipping/dtos/confirm-delivery-response.dto.ts
+++ b/backend/src/shipping/dtos/confirm-delivery-response.dto.ts
@@ -1,0 +1,21 @@
+import { OrderStatus } from '@common/enums/order-status.enum';
+
+export interface ConfirmDeliveryResponseDto {
+  message: string;
+  shippingInfo: {
+    id: string;
+    auctionId: string;
+    shippingStatus: string;
+    actualDelivery: Date | null;
+    updatedAt: Date;
+  };
+  orderInfo: {
+    status: OrderStatus;
+    completedAt: Date;
+  };
+  auctionInfo: {
+    id: string;
+    title: string;
+    winningBid: number;
+  };
+}

--- a/backend/src/shipping/shipping.constants.ts
+++ b/backend/src/shipping/shipping.constants.ts
@@ -67,11 +67,32 @@ export const SHIPPING_ERRORS = {
     message: 'Invalid sort field provided',
     errorCode: 'SHIPPING_INVALID_SORT_FIELD',
   },
+  DELIVERY_NOT_FOUND: {
+    statusCode: 404,
+    message: 'Shipping record not found',
+    errorCode: 'DELIVERY_NOT_FOUND',
+  },
+  DELIVERY_ACCESS_DENIED: {
+    statusCode: 403,
+    message: 'You are not authorized to confirm this delivery',
+    errorCode: 'DELIVERY_ACCESS_DENIED',
+  },
+  DELIVERY_INVALID_STATUS: {
+    statusCode: 400,
+    message: 'Can only confirm delivery for shipments in transit',
+    errorCode: 'DELIVERY_INVALID_STATUS',
+  },
+  DELIVERY_CONFIRMATION_FAILED: {
+    statusCode: 500,
+    message: 'Failed to confirm delivery. Please try again later.',
+    errorCode: 'DELIVERY_CONFIRMATION_FAILED',
+  },
 } as const;
 
 export const SHIPPING_MESSAGES = {
   FETCH_SUCCESS: 'Shipping records retrieved successfully',
   NO_RECORDS_FOUND: 'No shipping records found for the given criteria',
+  DELIVERY_CONFIRMED: 'Delivery confirmed successfully',
 } as const;
 
 export const VALIDATION_RULES = {

--- a/backend/src/shipping/shipping.controller.ts
+++ b/backend/src/shipping/shipping.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Patch,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import JwtAuthGuard from '@common/guards/jwt.guard';
 import { RoleGuard } from '@common/guards/role.guard';
 import { Roles } from '@common/decorators/roles.decorator';
@@ -10,6 +17,7 @@ import { GetBidderShippingsQueryDto } from './dtos/get-bidder-shippings-query.dt
 import { GetBidderShippingsResponseDto } from './dtos/get-bidder-shippings-response.dto';
 import { GetSellerShippingsQueryDto } from './dtos/get-seller-shippings-query.dto';
 import { GetSellerShippingsResponseDto } from './dtos/get-seller-shippings-response.dto';
+import { ConfirmDeliveryResponseDto } from './dtos/confirm-delivery-response.dto';
 
 @Controller('shipping')
 @UseGuards(JwtAuthGuard, RoleGuard)
@@ -32,5 +40,14 @@ export class ShippingController {
     @CurrentUser() user: TokenPayload,
   ): Promise<GetSellerShippingsResponseDto> {
     return this.shippingService.getSellerShippings(user.id, query);
+  }
+
+  @Patch(':shippingId/confirm-delivery')
+  @Roles(Role.BIDDER)
+  async confirmDelivery(
+    @Param('shippingId') shippingId: string,
+    @CurrentUser() user: TokenPayload,
+  ): Promise<ConfirmDeliveryResponseDto> {
+    return this.shippingService.confirmDelivery(shippingId, user.id);
   }
 }


### PR DESCRIPTION
https://edu-redmine.sun-asterisk.vn/projects/hn_22-naitei-nodejs-online_auction 

This pull request introduces a new feature allowing bidders to confirm delivery of their shipments, along with supporting updates to error handling, DTOs, and developer tooling. The main changes include a new endpoint for confirming delivery, the associated service logic, new error messages, and updates to the developer scripts for database management.

**Shipping Delivery Confirmation Feature:**

* Added a new `PATCH /shipping/:shippingId/confirm-delivery` endpoint in `ShippingController` that allows a bidder to confirm delivery of a shipment. This endpoint uses the new `confirmDelivery` method in the service and returns a detailed response DTO. [[1]](diffhunk://#diff-4a937580d47d11f8b4e82e8d25877dd2c89f865f1a4919eb06d1cbb85d184b67R44-R52) [[2]](diffhunk://#diff-4a937580d47d11f8b4e82e8d25877dd2c89f865f1a4919eb06d1cbb85d184b67L1-R8) [[3]](diffhunk://#diff-4a937580d47d11f8b4e82e8d25877dd2c89f865f1a4919eb06d1cbb85d184b67R20)
* Implemented the `confirmDelivery` method in `ShippingService`, which performs validation (existence, authorization, status), updates shipping and order records in a transaction, and returns structured confirmation info. Includes detailed error handling and logging. [[1]](diffhunk://#diff-1a068b2daba2988efe9dbe827428b3af3942225c7b9fe2d1ba242b6a6932ff9cR506-R603) [[2]](diffhunk://#diff-1a068b2daba2988efe9dbe827428b3af3942225c7b9fe2d1ba242b6a6932ff9cR6-R11) [[3]](diffhunk://#diff-1a068b2daba2988efe9dbe827428b3af3942225c7b9fe2d1ba242b6a6932ff9cR22-R27)

**DTOs and Error Handling:**

* Added `ConfirmDeliveryResponseDto` to define the response structure for delivery confirmation, including shipping, order, and auction info.
* Extended `SHIPPING_ERRORS` and `SHIPPING_MESSAGES` in `shipping.constants.ts` with new error codes and messages for delivery confirmation scenarios (not found, access denied, invalid status, confirmation failure, and success message).

**Developer Tooling and Scripts:**

* Added new npm scripts in `package.json` for seeding the database (`prisma:seed`), resetting the database (`db:reset`), and checking data (`check:data`). Also configured Prisma's seed command to use a TypeScript seed script. [[1]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5L23-R26) [[2]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R82-R84)